### PR TITLE
Fix RuntimeError: Download error (28) Timeout was reached

### DIFF
--- a/conda-enable.yml
+++ b/conda-enable.yml
@@ -15,7 +15,7 @@ steps:
 
 # install mamba
 - bash: |
-      conda config --set anaconda_upload yes --set always_yes yes --set solver libmamba && \
+      conda config --set anaconda_upload yes --set always_yes yes --set solver libmamba --set remote_read_timeout_secs 600 && \
       conda config --add channels conda-forge && \
       conda install -c conda-forge -q mamba conda-devenv libsolv conda-libmamba-solver && \
       mamba info && \


### PR DESCRIPTION
Fix RuntimeError: Download error (28) Timeout was reached by increasing timeout.

```
Run conda build without upload
...
RuntimeError: Download error (28) Timeout was reached [https://conda.anaconda.org/cadquery/noarch/repodata.json.zst]
Operation too slow. Less than 30 bytes/sec transferred the last 60 seconds

ERROR conda.cli.main_run:execute(124): `conda run conda mambabuild -c conda-forge -c cadquery .` failed. (See above for error)
```